### PR TITLE
Fix this warning by removing a unneeded use of defined

### DIFF
--- a/arch/arm/mm/alignment.c
+++ b/arch/arm/mm/alignment.c
@@ -699,7 +699,6 @@ do_alignment_t32_to_handler(unsigned long *pinstr, struct pt_regs *regs,
 	unsigned long instr = *pinstr;
 	u16 tinst1 = (instr >> 16) & 0xffff;
 	u16 tinst2 = instr & 0xffff;
-	poffset->un = 0;
 
 	switch (tinst1 & 0xffe0) {
 	/* A6.3.5 Load/Store multiple */
@@ -795,7 +794,7 @@ do_alignment(unsigned long addr, unsigned int fsr, struct pt_regs *regs)
  fixup:
 
 	regs->ARM_pc += isize;
-
+         offset.un = 0; 
 	switch (CODING_BITS(instr)) {
 	case 0x00000000:	/* 3.13.4 load/store instruction extensions */
 		if (LDSTHD_I_BIT(instr))

--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -370,7 +370,7 @@ if ($hz eq '--can') {
 	}
 
 	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
+	if (!@val) { 
 		@val = compute_values($hz);
 	}
 	output($hz, @val);


### PR DESCRIPTION
TIMEC   kernel/timeconst.h
defined(@array) is deprecated at kernel/timeconst.pl line 373.
  (Maybe you should just omit the defined()?)
http://linux-kernel.2935.n7.nabble.com/PATCH-1-5-kbuild-remove-deprecated-use-of-defined-in-timeconst-pl-td556009.html
